### PR TITLE
Remove deprecated call

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -29,28 +29,6 @@ class Translator implements
     }
 
     /**
-     * Proxy unknown method calls to underlying translator instance
-     *
-     * Note: this method is only implemented to keep backwards compatibility
-     * with pre-2.3.0 code.
-     *
-     * @deprecated
-     * @param string $method
-     * @param array $args
-     * @return mixed
-     */
-    public function __call($method, array $args)
-    {
-        if (! method_exists($this->translator, $method)) {
-            throw new Exception\BadMethodCallException(sprintf(
-                'Unable to call method "%s"; does not exist in translator',
-                $method
-            ));
-        }
-        return call_user_func_array([$this->translator, $method], $args);
-    }
-
-    /**
      * @return I18nTranslatorInterface
      */
     public function getTranslator()

--- a/test/TranslatorTest.php
+++ b/test/TranslatorTest.php
@@ -42,12 +42,4 @@ class TranslatorTest extends TestCase
     {
         $this->assertSame($this->i18nTranslator, $this->translator->getTranslator());
     }
-
-    public function testCanProxyToComposedTranslatorMethods()
-    {
-        $this->i18nTranslator->expects($this->once())
-            ->method('setLocale')
-            ->with($this->equalTo('en_US'));
-        $this->translator->setLocale('en_US');
-    }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| BC Break      | yes

### Description

re-create https://github.com/laminas/laminas-mvc-i18n/issues/2 remove deprecated `__call()`

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
